### PR TITLE
Change default version to v3.3.2 (latest)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
   yq-version:  # id of input
     description: 'What version of YQ to install'
     required: false
-    default: '2.4.1'
+    default: '3.3.2'
   yq-url:
     description: 'The url to download YQ from'
     required: false


### PR DESCRIPTION
Specifying the version works also, but maybe it's time to update the default to the latest version.

I've tested this on our pipelines without any issues.

Thanks for making this action, and also for making it future-proof. 