### PR TITLE
Update actions toolkit to fix addPath.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "Chris Dickinson <chris@neversaw.us> (http://neversaw.us/)",
   "license": "Apache-2.0",
   "dependencies": {
-    "@actions/core": "^1.2.0",
+    "@actions/core": "^1.2.6",
     "@actions/tool-cache": "^1.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
So, Github made a booboo, and now workflows are starting to break.

https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

This updates the dependencies of the actions toolkit. Fixes #2 