### PR TITLE
Update node version to node14

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     required: false
     default: 'https://github.com/mikefarah/yq/releases/download/{version}/yq_{platform}_{arch}'
 runs:
-  using: 'node12'
+  using: 'node14'
   main: 'dist/index.js'
 icon: book-open
 color: '#FFFF00'


### PR DESCRIPTION
Fixes a warning since node12 actions are now deprecated:

<img width="1469" alt="image" src="https://user-images.githubusercontent.com/774686/196072247-d4d57266-cb1a-4019-864a-b753a94e8d64.png">

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/