### PR TITLE
Chore: update to use node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     required: false
     default: 'https://github.com/mikefarah/yq/releases/download/{version}/yq_{platform}_{arch}'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 icon: book-open
 color: '#FFFF00'


### PR DESCRIPTION
Fixes a warning to update to node 20

<img width="1398" alt="Screen Shot 2024-01-31 at 12 16 09 PM" src="https://github.com/chrisdickinson/setup-yq/assets/13505030/d4ebc7f1-b38f-499b-83a1-0ee4a4436a2d">

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/